### PR TITLE
Initial version of serverless-sns-offline

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,111 @@
+{
+  "env": {
+    "es6": true
+  },
+  "globals": {},
+  "rules": {
+    "no-debugger": 2,
+    "no-eval": 2,
+    "no-implied-eval": 2,
+    "eqeqeq": 2,
+    /*"newline-after-var": 2,*/
+    /*"no-unused-vars": 2,*/
+    /*"new-cap": 2,*/
+    "no-multi-str": 2,
+    "no-new-wrappers": 2,
+    "no-array-constructor": 2,
+    "no-new-object": 2,
+    "no-dupe-keys": 2,
+    "no-dupe-args": 2,
+    "indent": 2,
+    "no-new": 2,
+    "no-redeclare": 2,
+    "no-undefined": 2,
+    "semi": 2,
+    "camelcase": [
+      2,
+      {
+        "properties": "never"
+      }
+    ],
+    "dot-notation": [2, {
+        "allowPattern": "^[a-z|1-9]+(_[a-z|1-9]+)+$"
+    }],
+    "curly": [
+      2,
+      "all"
+    ],
+    "space-return-throw-case": 0,
+    "keyword-spacing": 2,
+    "space-before-blocks": [
+      2,
+      "always"
+    ],
+    "space-before-function-paren": [
+      2,
+      "always"
+    ],
+    "no-empty": 2,
+    "space-in-parens": [
+      2,
+      "never"
+    ],
+    "key-spacing": [
+      2,
+      {
+        "beforeColon": false,
+        "afterColon": true
+      }
+    ],
+    "block-scoped-var": 2,
+    "no-multi-spaces": 2,
+    "comma-style": [
+      2,
+      "last"
+    ],
+    "operator-linebreak": [
+      2,
+      "after"
+    ],
+    "space-infix-ops": 2,
+    "space-unary-ops": 2,
+    "no-implicit-coercion": [
+      2,
+      {
+        "number": true,
+        "boolean": true,
+        "string": true
+      }
+    ],
+    "no-with": 2,
+    "no-multiple-empty-lines": 2,
+    "linebreak-style": [
+      2,
+      "unix"
+    ],
+    "quotes": [
+      2,
+      "single"
+    ],
+    "no-mixed-spaces-and-tabs": 2,
+    "no-trailing-spaces": 2,
+    "no-path-concat": 2,
+    "comma-dangle": [
+      2,
+      "never"
+    ],
+    "brace-style": 2,
+    "max-len": [
+      2,
+      120
+    ],
+    "consistent-this": [
+      2,
+      "$this"
+    ],
+    "yoda": [
+      2,
+      "never"
+    ]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "4.3.2"
+before_script:
+  - npm install -g eslint
+script: npm test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# serverless-offline-sns
+serverless-offline-sns [![Build Status](https://travis-ci.org/rockabox/serverless-offline-sns.svg?branch=master)](https://travis-ci.org/rockabox/serverless-offline-sns)
+==================
+Simple implementation of a fake SNS server for serverless-offline
+
+Currently only implements sending SNS messages to lamba functions configured
+through Serverless (with no authentication).
+
+When included as a plugin in the Serverless configuration along with
+serverless-offline, an HTTP server will be started to listen for SNS message
+publish messages. The SNS events in the Serverless configuration will be read and the associated handlers will be run whenever a SNS message of the given
+topic is received.
+
+The HTTP server should be configured as the SNS endpoint for messages that
+should be sent to the Lambda functions.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var server = require('./lib/server');
+
+class OfflineSNS {
+    constructor (serverless, options) {
+        this.serverless = serverless;
+        this.options = options;
+        const start = this.start.bind(this);
+
+        this.hooks = {
+            'offline:start:init': start,
+            'offline:start': start
+        };
+    }
+
+    start () {
+        server.create(this.serverless, this.options);
+        server.parseSLSConfig(this.serverless);
+        return server.listen();
+    }
+}
+
+module.exports = OfflineSNS;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const Hapi = require('hapi'),
+    path = require('path'),
+    uuid = require('uuid/v1'),
+    fs = require('fs'),
+    jsontoxml = require('jsontoxml'),
+    corsHeaders = require('hapi-cors-headers'),
+    functionHelper = require('serverless-offline/src/functionHelper'),
+    createLambdaContext = require('serverless-offline/src/createLambdaContext');
+
+var _server;
+var _options;
+var _serverless;
+var _log;
+var _topics = {};
+var _connectionOptions;
+
+module.exports.create = (serverless, options) => {
+    _options = options || {};
+    _options.location = _options.location || '.';
+    _serverless = serverless;
+    _log = _serverless.cli.log.bind(_serverless.cli);
+
+    _server = new Hapi.Server({
+        connections: {
+            router: {
+                stripTrailingSlash: true
+            }
+        }
+    });
+
+    _connectionOptions = {
+        host: process.env.SNS_HOST || _options.host,
+        port: process.env.SNS_PORT || 9493
+    };
+    const httpsDir = _options.httpsProtocol;
+
+    // HTTPS support
+    if (typeof httpsDir === 'string' && httpsDir.length > 0) {
+        _connectionOptions.tls = {
+            key: fs.readFileSync(path.resolve(httpsDir, 'key.pem'), 'ascii'),
+            cert: fs.readFileSync(path.resolve(httpsDir, 'cert.pem'), 'ascii')
+        };
+    }
+
+    // Passes the configuration object to the server
+    _server.connection(_connectionOptions);
+
+    // Enable CORS preflight response
+    _server.ext('onPreResponse', corsHeaders);
+};
+
+module.exports.parseSLSConfig = (serverless) => {
+    const service = serverless.service;
+
+    if (typeof service === 'object' && typeof service.functions === 'object') {
+        Object.keys(service.functions).forEach(key => {
+            const serviceFunction = service.getFunction(key);
+            const servicePath = path.join(_serverless.config.servicePath, _options.location);
+
+            serviceFunction.events.forEach(event => {
+                if (!event.sns) {
+                    return;
+                }
+
+                let topicName;
+                if (typeof event.sns === 'string') {
+                    topicName = event.sns;
+                } else if (typeof event.sns === 'object') {
+                    topicName = event.sns.topicName;
+                }
+
+                _log(`Found SNS listener for ${topicName}`);
+
+                if (typeof _topics[topicName] === 'undefined') {
+                    _topics[topicName] = {
+                        handlers: []
+                    };
+                }
+
+                // Add function to topic handlers
+                _topics[topicName].handlers.push({
+                    name: key,
+                    subscriptionId: uuid(),
+                    context: serviceFunction,
+                    options: functionHelper.getFunctionOptions(serviceFunction, key, servicePath)
+                });
+            });
+        });
+    }
+
+    _server.route({
+        method: '*',
+        path: '/',
+        handler: (request, reply) => {
+            if (typeof request.payload === 'object') {
+                if (request.payload.TopicArn) {
+                    const topicArn = request.payload.TopicArn;
+                    const message = request.payload.Message;
+                    _log(`Received message for ${topicArn}`);
+
+                    // Generate Message ID
+                    const messageId = uuid();
+                    const requestId = uuid();
+
+                    // Reply with XML if good
+                    const response = {
+                        PublishResponse: {
+                            attr: {
+                                xmlns: 'http://sns.amazonaws.com/doc/2010-03-31/'
+                            },
+                            PublishResult: {
+                                MessageId: messageId
+                            },
+                            ResponseMetadata: {
+                                RequestId: requestId
+                            }
+                        }
+                    };
+
+                    reply(jsontoxml(response)).code(200).type('application/xml');
+
+                    const topic = _topics[topicArn];
+                    if (typeof topic !== 'undefined') {
+                        // Build the fake SNSEvent object
+                        let snsEvent = {
+                            Records: [
+                                {
+                                    EventSource: 'aws:sns',
+                                    EventVersion: '1.0',
+                                    Sns: {
+                                        Type: 'Notification',
+                                        MessageId: messageId,
+                                        TopicArn: topicArn,
+                                        Subject: request.payload.Subject,
+                                        Message: message
+                                    }
+                                }
+                            ]
+                        };
+
+                        topic.handlers.forEach(handlerItem => {
+                            const lambdaContext = createLambdaContext(handlerItem.context);
+                            const handler = functionHelper.createHandler(handlerItem.options, _options);
+
+                            snsEvent.Records[0].EventSubscription = `${topicArn}:${handlerItem.subscriptionId}`;
+
+                            // Try and call handler
+                            try {
+                                handler(snsEvent, lambdaContext);
+                            } catch (error) {
+                                _log(`Uncaught error in your '${handlerItem.name}' handler`, error);
+                            }
+                        });
+                    }
+
+                    return;
+                }
+            }
+
+            // Send Error response
+            reply().code(400);
+        }
+    });
+};
+
+module.exports.listen = () => {
+    return new Promise((resolve, reject) => {
+        _server.start(err => {
+            if (err) {
+                return reject(err);
+            }
+
+            _log('Offline SNS listening on http' + (_connectionOptions.tls ? 's' : '') +
+                '://' + _connectionOptions.host + ':' + _connectionOptions.port);
+
+            resolve(_server);
+        });
+    });
+};
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "serverless-offline-sns",
+  "version": "1.0.0",
+  "description": "Simple implementation of a fake SNS server for serverless-offline",
+  "main": "index.js",
+  "scripts": {
+    "test": "eslint index.js lib/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rockabox/serverless-offline-sns"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "hapi": "~16.0.1",
+    "hapi-cors-headers": "~1.0.0",
+    "jsontoxml": "0.0.11",
+    "uuid": "~3.0.1"
+  },
+  "devDependencies": {
+    "aws-sdk": "~2.7.13"
+  },
+  "peerDependencies": {
+    "serverless-offline": "~3.5.7"
+  }
+}


### PR DESCRIPTION
Implements receiving of SNS message from the AWS-sdk and passing them to
the subscribed Lambda functions.

Based heavily off (and uses the libraries of) serverless-offline's AWS API implementation. It will run when the sls offline command is run, listening to the offline:start and offline:start:init hooks.