### PR TITLE
better compatibility with serverless-offline

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ var _serverless;
 var _log = () => {};
 var _topics = {};
 var _connectionOptions;
+var _originalEnvironment = {};
 
 /**
  * Add a function a handle the incoming SNS messages
@@ -38,9 +39,20 @@ var addHandler = module.exports.addHandler = (handler) => {
  * @param {string} [options.host] Host address for the server to listen on
  */
 module.exports.create = (serverless, options) => {
-    _options = options || {};
+    const defaultOpts = {
+        host: process.env.SNS_HOST || 'localhost',
+        port: options.snsport || process.env.SNS_PORT || 9493
+    };
+
+    _options = Object.assign({}, defaultOpts, (serverless.service.custom || {})['serverless-offline-sns'], options);
     _options.location = _options.location || '.';
     _serverless = serverless;
+
+    // Some users would like to know their environment outside of the handler
+    process.env.IS_OFFLINE = true;
+
+    _originalEnvironment = Object.assign({}, process.env);
+
     if (serverless) {
         _log = _serverless.cli.log.bind(_serverless.cli);
     }
@@ -54,9 +66,10 @@ module.exports.create = (serverless, options) => {
     });
 
     _connectionOptions = {
-        host: _options.host || process.env.SNS_HOST,
-        port: _options.snsport || process.env.SNS_PORT || 9493
+        host: _options.host,
+        port: _options.port
     };
+
     const httpsDir = _options.httpsProtocol;
 
     // HTTPS support
@@ -218,7 +231,13 @@ module.exports.parseSLSConfig = (serverless) => {
 
                         // Try and call handler
                         try {
-                            handler(snsEvent, lambdaContext);
+                            process.env = Object.assign({},
+                                _serverless.service.provider.environment,
+                                _serverless.service.functions[handlerItem.name].environment,
+                                _originalEnvironment
+                            );
+
+                            handler(snsEvent, lambdaContext, lambdaContext.done);
                         } catch (error) {
                             _log(`Uncaught error in your '${handlerItem.name}' handler`, error);
                         }


### PR DESCRIPTION
I've added new functionality to have better compatibility with serverless-offline plugin.

✅ `process.env.IS_OFFLINE` set to `true` to identify offline environment
✅ populate `process.env` with function environment values
✅ plugin configuration inside `serverless.yml` config file under `custom.serverless-offline-sns` section

Thanks,